### PR TITLE
feat(bobby): add Telegram channel for Operator phone chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ dist-ssr
 __unconfig*
 todos.json
 apps/portfolio/scripts/og-fonts/
+.vercel
+.env*

--- a/apps/bobby/AGENTS.md
+++ b/apps/bobby/AGENTS.md
@@ -4,3 +4,24 @@ Operator business co-pilot. Domain: `CONTEXT.md`. Requires **Node 24**.
 
 Before writing eve code, read the installed package docs (`node_modules/eve/docs/`
 from this app or the workspace root after `bun install`). Fallback: https://eve.dev/docs.
+
+## Telegram (Operator phone)
+
+Channel: `agent/channels/telegram.ts` → `POST /eve/v1/telegram`.
+
+Env (Vercel project `bobby`, Production + Preview):
+
+- `TELEGRAM_BOT_TOKEN` — from BotFather
+- `TELEGRAM_WEBHOOK_SECRET_TOKEN` — random secret you choose; must match `setWebhook`
+- `TELEGRAM_ALLOWED_USER_IDS` — your Telegram numeric user id (comma-separated)
+- `TELEGRAM_BOT_USERNAME` — bot username without `@` (optional; needed for groups)
+
+Register webhook after deploy (Eve does not call `setWebhook` for you):
+
+```bash
+curl -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://<bobby-host>/eve/v1/telegram",
+       "secret_token":"'"$TELEGRAM_WEBHOOK_SECRET_TOKEN"'",
+       "allowed_updates":["message","callback_query"]}'
+```

--- a/apps/bobby/CONTEXT.md
+++ b/apps/bobby/CONTEXT.md
@@ -25,5 +25,6 @@ _Avoid_: Session-only `defineState` for cross-session memory; inventing memories
 ## Relationships
 
 - **Bobby → Portal / backend**: Bobby consumes Operator-scoped APIs; Portal remains the workspace UI (ADR-0003 Client Desk).
+- **Bobby ↔ Operator (Telegram)**: Primary phone channel for Operator chat (ADR-0002). Gated by Telegram user id allowlist.
 - **Bobby ↛ Client**: No Client-facing chat channel in v0; communication stays outside Portal.
 - **Bobby ≠ Bonny**: Separate agent/identity later for life OS.

--- a/apps/bobby/agent/channels/telegram.ts
+++ b/apps/bobby/agent/channels/telegram.ts
@@ -1,0 +1,41 @@
+import { defaultTelegramAuth, telegramChannel } from "eve/channels/telegram";
+
+/**
+ * Comma-separated Telegram user ids allowed to talk to Bobby.
+ * Empty = anyone who can message the bot (dev only — set this in production).
+ */
+const allowedUserIds = new Set(
+  (process.env.TELEGRAM_ALLOWED_USER_IDS ?? "")
+    .split(",")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0),
+);
+
+export default telegramChannel({
+  // Without @: used for group @mentions /commands. Private DMs work either way.
+  botUsername: process.env.TELEGRAM_BOT_USERNAME || undefined,
+  uploadPolicy: {
+    allowedMediaTypes: ["image/*", "application/pdf"],
+    maxBytes: 10 * 1024 * 1024,
+  },
+  async onMessage(ctx, message) {
+    if (message.from?.isBot === true || message.chat.type !== "private") {
+      return null;
+    }
+
+    const text = message.text || message.caption;
+    if (text.trim().length === 0 && message.attachments.length === 0) {
+      return null;
+    }
+
+    if (allowedUserIds.size > 0) {
+      const userId = message.from?.id;
+      if (!userId || !allowedUserIds.has(userId)) {
+        return null;
+      }
+    }
+
+    await ctx.telegram.startTyping();
+    return { auth: defaultTelegramAuth(message) };
+  },
+});

--- a/apps/bobby/docs/adr/0002-telegram-operator-channel.md
+++ b/apps/bobby/docs/adr/0002-telegram-operator-channel.md
@@ -1,0 +1,24 @@
+# Telegram as Operator channel for Bobby
+
+## Status
+
+Accepted
+
+## Context
+
+The Operator (Hezaerd) primarily reaches Bobby from a phone. Eve’s default HTTP
+channel is for local/dev and web clients. Eve ships a first-class Telegram
+channel with webhook verification, private DMs, attachments, and HITL buttons.
+
+## Decision
+
+Bobby exposes `agent/channels/telegram.ts` for Operator ↔ Bobby chat. Access is
+gated by `TELEGRAM_ALLOWED_USER_IDS` (Operator Telegram user id). Clients never
+use this channel.
+
+## Consequences
+
+Requires BotFather bot + `TELEGRAM_BOT_TOKEN` + `TELEGRAM_WEBHOOK_SECRET_TOKEN`
+on the Vercel project, and a one-time `setWebhook` to
+`https://<bobby-host>/eve/v1/telegram`. WhatsApp / native iOS remain out of
+scope until a second Operator surface is justified.

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,13 @@
         "WORKOS_COOKIE_PASSWORD",
         "WORKOS_REDIRECT_URI",
         "CONVEX_DEPLOY_KEY"
+      ],
+      "passThroughEnv": [
+        "AI_GATEWAY_API_KEY",
+        "TELEGRAM_BOT_TOKEN",
+        "TELEGRAM_WEBHOOK_SECRET_TOKEN",
+        "TELEGRAM_BOT_USERNAME",
+        "TELEGRAM_ALLOWED_USER_IDS"
       ]
     },
     "typecheck": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Eve’s Telegram channel so the Operator can chat with Bobby from a phone.

## What’s in

- `apps/bobby/agent/channels/telegram.ts` — private DMs only, optional `TELEGRAM_ALLOWED_USER_IDS` allowlist, image/PDF uploads
- ADR-0002 + CONTEXT/AGENTS notes
- `turbo.json` passThroughEnv for Telegram + AI Gateway secrets

## Live setup (already done on Vercel project `bobby`)

- Env: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET_TOKEN`, `TELEGRAM_BOT_USERNAME=BobbyHezaerdBot`
- Webhook → `https://clyde-delta-nine.vercel.app/eve/v1/telegram`
- Prod deploy includes this branch

Still missing: `TELEGRAM_ALLOWED_USER_IDS` (Operator Telegram numeric id) — bot is open until set.

## Stacked on

Depends on #9 (Clyde → Bobby rename). Base: `cursor/rename-clyde-to-bobby-9a61`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9a46-eb62-7652-9dba-483597fd9a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9a46-eb62-7652-9dba-483597fd9a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

