### PR TITLE
feat(bobby): register Telegram webhook without laptop curl

### DIFF
--- a/apps/bobby/AGENTS.md
+++ b/apps/bobby/AGENTS.md
@@ -16,16 +16,15 @@ Env (Vercel project `bobby`, Production + Preview):
 - `TELEGRAM_ALLOWED_USER_IDS` — your Telegram numeric user id (comma-separated)
 - `TELEGRAM_BOT_USERNAME` — bot username without `@` (optional; needed for groups)
 
-Production host: `https://bobby.hezaerd.com`. After any domain change, re-run
-`setWebhook` (Eve does not call it for you). Old hosts like
-`clyde-delta-nine.vercel.app` stop receiving updates.
+Production host: `https://bobby.hezaerd.com`.
+
+Webhook registration (no Bot token on the laptop needed):
+
+1. Prefer: `POST https://bobby.hezaerd.com/eve/v1/telegram/ensure-webhook`
+   — uses Vercel env; only ever points at production (or `TELEGRAM_WEBHOOK_URL`).
+2. Hourly schedule `register-telegram-webhook` self-heals after domain drift.
+3. Manual Bot API `setWebhook` still works if you have the token locally.
 
 ```bash
-curl -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
-  -H "Content-Type: application/json" \
-  -d '{"url":"https://bobby.hezaerd.com/eve/v1/telegram",
-       "secret_token":"'"$TELEGRAM_WEBHOOK_SECRET_TOKEN"'",
-       "allowed_updates":["message","callback_query"]}'
+curl -X POST "https://bobby.hezaerd.com/eve/v1/telegram/ensure-webhook"
 ```
-
-Verify: `curl -sS "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/getWebhookInfo" | jq .`

--- a/apps/bobby/AGENTS.md
+++ b/apps/bobby/AGENTS.md
@@ -22,7 +22,7 @@ Webhook registration (no Bot token on the laptop needed):
 
 1. Prefer: `POST https://bobby.hezaerd.com/eve/v1/telegram/ensure-webhook`
    — uses Vercel env; only ever points at production (or `TELEGRAM_WEBHOOK_URL`).
-2. Hourly schedule `register-telegram-webhook` self-heals after domain drift.
+2. Daily schedule `register-telegram-webhook` self-heals after domain drift.
 3. Manual Bot API `setWebhook` still works if you have the token locally.
 
 ```bash

--- a/apps/bobby/agent/channels/telegram-setup.ts
+++ b/apps/bobby/agent/channels/telegram-setup.ts
@@ -1,0 +1,19 @@
+import { defineChannel, POST } from "eve/channels";
+
+import { registerTelegramWebhook } from "../lib/register-telegram-webhook";
+
+/**
+ * Phone-friendly / agent-triggerable webhook registration.
+ * Only ever points the bot at TELEGRAM_WEBHOOK_URL or production bobby.hezaerd.com
+ * (uses server env for the bot token — callers cannot redirect the bot elsewhere).
+ */
+export default defineChannel({
+  routes: [
+    POST("/eve/v1/telegram/ensure-webhook", async (_req, { waitUntil }) => {
+      const resultPromise = registerTelegramWebhook();
+      waitUntil(resultPromise);
+      const result = await resultPromise;
+      return Response.json(result, { status: result.ok ? 200 : 500 });
+    }),
+  ],
+});

--- a/apps/bobby/agent/lib/register-telegram-webhook.ts
+++ b/apps/bobby/agent/lib/register-telegram-webhook.ts
@@ -1,0 +1,94 @@
+/** Production Telegram webhook for Bobby. Override with TELEGRAM_WEBHOOK_URL. */
+const DEFAULT_PRODUCTION_WEBHOOK_URL =
+  "https://bobby.hezaerd.com/eve/v1/telegram";
+
+export type RegisterTelegramWebhookResult =
+  | { ok: true; url: string; skipped: true; reason: string }
+  | { ok: true; url: string; skipped: false; alreadySet: boolean }
+  | { ok: false; error: string };
+
+function resolveWebhookUrl(): string | null {
+  const explicit = process.env.TELEGRAM_WEBHOOK_URL?.trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  // Never point the live bot at a preview/dev host.
+  if (process.env.VERCEL_ENV === "production") {
+    return DEFAULT_PRODUCTION_WEBHOOK_URL;
+  }
+
+  return null;
+}
+
+/**
+ * Points BotFather's webhook at Bobby's production Telegram route.
+ * Safe to call repeatedly (no-ops when already correct).
+ */
+export async function registerTelegramWebhook(): Promise<RegisterTelegramWebhookResult> {
+  const url = resolveWebhookUrl();
+  if (!url) {
+    return {
+      ok: true,
+      url: "",
+      skipped: true,
+      reason: "not production and TELEGRAM_WEBHOOK_URL unset",
+    };
+  }
+
+  const token = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  const secret = process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN?.trim();
+  if (!token || !secret) {
+    return {
+      ok: false,
+      error: "missing TELEGRAM_BOT_TOKEN or TELEGRAM_WEBHOOK_SECRET_TOKEN",
+    };
+  }
+
+  const infoResponse = await fetch(
+    `https://api.telegram.org/bot${token}/getWebhookInfo`,
+  );
+  const infoBody: unknown = await infoResponse.json();
+  if (
+    isTelegramOk(infoBody) &&
+    typeof infoBody.result === "object" &&
+    infoBody.result !== null &&
+    "url" in infoBody.result &&
+    infoBody.result.url === url
+  ) {
+    return { ok: true, url, skipped: false, alreadySet: true };
+  }
+
+  const setResponse = await fetch(
+    `https://api.telegram.org/bot${token}/setWebhook`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        url,
+        secret_token: secret,
+        allowed_updates: ["message", "callback_query"],
+      }),
+    },
+  );
+  const setBody: unknown = await setResponse.json();
+  if (!isTelegramOk(setBody)) {
+    return {
+      ok: false,
+      error: `setWebhook failed: ${JSON.stringify(setBody)}`,
+    };
+  }
+
+  return { ok: true, url, skipped: false, alreadySet: false };
+}
+
+function isTelegramOk(
+  body: unknown,
+): body is { ok: true; result?: unknown } {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "ok" in body &&
+    body.ok === true
+  );
+}

--- a/apps/bobby/agent/schedules/register-telegram-webhook.ts
+++ b/apps/bobby/agent/schedules/register-telegram-webhook.ts
@@ -1,0 +1,23 @@
+import { defineSchedule } from "eve/schedules";
+
+import { registerTelegramWebhook } from "../lib/register-telegram-webhook";
+
+/** Self-heal webhook URL after domain/deploy drift (UTC hourly). */
+export default defineSchedule({
+  cron: "0 * * * *",
+  async run() {
+    const result = await registerTelegramWebhook();
+    if (!result.ok) {
+      console.error("[telegram-webhook]", result.error);
+      return;
+    }
+    if (result.skipped) {
+      return;
+    }
+    console.log(
+      "[telegram-webhook]",
+      result.alreadySet ? "already set" : "updated",
+      result.url,
+    );
+  },
+});

--- a/apps/bobby/agent/schedules/register-telegram-webhook.ts
+++ b/apps/bobby/agent/schedules/register-telegram-webhook.ts
@@ -2,9 +2,9 @@ import { defineSchedule } from "eve/schedules";
 
 import { registerTelegramWebhook } from "../lib/register-telegram-webhook";
 
-/** Self-heal webhook URL after domain/deploy drift (UTC hourly). */
+/** Self-heal webhook URL after domain/deploy drift (once daily UTC; Hobby cron limit). */
 export default defineSchedule({
-  cron: "0 * * * *",
+  cron: "0 12 * * *",
   async run() {
     const result = await registerTelegramWebhook();
     if (!result.ok) {

--- a/apps/bobby/docs/adr/0002-telegram-operator-channel.md
+++ b/apps/bobby/docs/adr/0002-telegram-operator-channel.md
@@ -19,7 +19,9 @@ use this channel.
 ## Consequences
 
 Requires BotFather bot + `TELEGRAM_BOT_TOKEN` + `TELEGRAM_WEBHOOK_SECRET_TOKEN`
-on the Vercel project, and `setWebhook` to
-`https://bobby.hezaerd.com/eve/v1/telegram` (re-run after domain changes).
+on the Vercel project. Webhook URL is
+`https://bobby.hezaerd.com/eve/v1/telegram`, registered via
+`POST /eve/v1/telegram/ensure-webhook` or the hourly
+`register-telegram-webhook` schedule (not only a laptop `setWebhook`).
 WhatsApp / native iOS remain out of scope until a second Operator surface is
 justified.

--- a/apps/bobby/docs/adr/0002-telegram-operator-channel.md
+++ b/apps/bobby/docs/adr/0002-telegram-operator-channel.md
@@ -21,7 +21,7 @@ use this channel.
 Requires BotFather bot + `TELEGRAM_BOT_TOKEN` + `TELEGRAM_WEBHOOK_SECRET_TOKEN`
 on the Vercel project. Webhook URL is
 `https://bobby.hezaerd.com/eve/v1/telegram`, registered via
-`POST /eve/v1/telegram/ensure-webhook` or the hourly
+`POST /eve/v1/telegram/ensure-webhook` or the daily
 `register-telegram-webhook` schedule (not only a laptop `setWebhook`).
 WhatsApp / native iOS remain out of scope until a second Operator surface is
 justified.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Operator was on phone and couldn’t run `setWebhook` with BotFather secrets.

## What

- `POST /eve/v1/telegram/ensure-webhook` — server uses Vercel env to call Telegram `setWebhook` for `https://bobby.hezaerd.com/eve/v1/telegram`
- Daily schedule self-heals URL drift (Hobby cron = once/day)
- Docs updated in `AGENTS.md` / ADR-0002

## Already live

Triggered on production:

```json
{"ok":true,"url":"https://bobby.hezaerd.com/eve/v1/telegram","skipped":false,"alreadySet":false}
```

DM `@BobbyHezaerdBot` to confirm. Merge lands the same code on `master` so future deploys keep the endpoint.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9ecc-0d47-7956-ae16-f003e4d1d9b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9ecc-0d47-7956-ae16-f003e4d1d9b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

