### PR TITLE
fix(backend): unblock portal prod deploy + restore WorkOS login

### DIFF
--- a/packages/backend/convex/clients.ts
+++ b/packages/backend/convex/clients.ts
@@ -38,7 +38,7 @@ export const list = operatorQuery({
   returns: v.array(clientValidator),
   handler: async (ctx) => {
     const clients = await ctx.db.query("clients").collect();
-    return clients.toSorted((a, b) => a.name.localeCompare(b.name, "fr"));
+    return [...clients].sort((a, b) => a.name.localeCompare(b.name, "fr"));
   },
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Portal deployments/logins were broken in two places:

1. **Vercel Authentication (SSO)** on `hezaerd-portal` was forcing `vercel.com/sso-api` on `dev.portal.hezaerd.com`, so WorkOS login never ran.
2. **Production** stuck on an old build: every master deploy failed Convex typecheck (`Array#toSorted` needs ES2023; Convex `tsc` still uses ES2021). That left prod on a pre–turbo-env build → WorkOS env vars never reached the app → `portal.hezaerd.com` 500s.

## Fix

- **Applied on Vercel (live):** disabled SSO protection on `hezaerd-portal` (`ssoProtection: null`). Preview custom domain now serves the app; `/api/auth/sign-in` redirects to WorkOS.
- **This PR:** replace `toSorted` with `[...clients].sort(...)` so production Convex deploy typechecks and can ship the already-merged turbo env passthrough.

## Verify

1. Open https://dev.portal.hezaerd.com → login screen (not Vercel SSO)
2. Click Continuer → WorkOS AuthKit
3. After merge: production deploy on master should go READY; https://portal.hezaerd.com should stop 500ing and offer WorkOS login

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9fb8-61b4-78a7-a690-b510981afa4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9fb8-61b4-78a7-a690-b510981afa4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

